### PR TITLE
Harden main.js to work across templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, render_template, request, redirect, url_for, jsonify
 from flask_migrate import Migrate
+from sqlalchemy.orm import joinedload
 from models import db, Professor, University, Department, Program, ResearchArea
 from models import HiringStatus, ContactThrough
 
@@ -239,6 +240,19 @@ def delete_professor(professor_id):
     except Exception as e:
         db.session.rollback()
         return {'error': str(e)}, 500
+
+@app.route('/programs')
+def programs_list():
+    programs = (
+        Program.query
+        .options(
+            joinedload(Program.department).joinedload(Department.university)
+        )
+        .join(Department).join(University)
+        .order_by(University.name.asc(), Department.name.asc(), Program.name.asc())
+        .all()
+    )
+    return render_template("programs_list.html", programs=programs)
     
 if __name__ == '__main__':
     with app.app_context():

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -53,7 +53,7 @@ function deleteProfessor(professorId) {
 }
 
 // Confirm deletion when the confirm button is clicked
-document.getElementById('confirmDeleteBtn').addEventListener('click', function() {
+document.getElementById('confirmDeleteBtn')?.addEventListener('click', function() { // Optional chaining
     if (professorToDelete !== null) {
         // Send a DELETE request to the server
         fetch(`/delete_professor/${professorToDelete}`, {
@@ -69,7 +69,7 @@ document.getElementById('confirmDeleteBtn').addEventListener('click', function()
                 if (row) {
                     row.remove();
                 }
-                
+
                 // Hide the modal
                 const modal = bootstrap.Modal.getInstance(document.getElementById('deleteModal'));
                 modal.hide();
@@ -99,9 +99,16 @@ function debounce(fn, delay = 250) {
     t = setTimeout(() => fn(...args), delay);
   };
 }
+const toNum = (v, fallback = NaN) => {
+  const n = Number(v); return Number.isFinite(n) ? n : fallback;
+};
 
 // --- core filtering ---
 function filterTable() {
+  // Check if professor table exists before running this function
+  const profTable = document.getElementById('professorTable');
+  if (!profTable) return; // Exit if not on the professor page
+
   // Search only these fields:
   // name + location (country, city, state)
   const tokens = tokenize(document.getElementById('globalSearch').value);
@@ -155,6 +162,10 @@ function filterTable() {
 
 // --- sorting ---
 function sortRows() {
+  // Check if professor table exists before running this function
+  const profTable = document.getElementById('professorTable');
+  if (!profTable) return; // Exit if not on the professor page
+
   const sortBy = document.getElementById('sortBy').value;
   if (!sortBy) return;
 
@@ -185,6 +196,10 @@ function sortRows() {
 
 // --- clear ---
 function clearFilters() {
+  // Check if professor table exists before running this function
+  const profTable = document.getElementById('professorTable');
+  if (!profTable) return; // Exit if not on the professor page
+
   document.getElementById('globalSearch').value = '';
   document.getElementById('filterHiringStatus').value = '';
   document.getElementById('filterContactMethod').value = '';
@@ -198,15 +213,20 @@ function clearFilters() {
 }
 
 // --- wire up live filtering ---
-document.getElementById('globalSearch').addEventListener('input', debounce(filterTable, 200));
-document.getElementById('filterHiringStatus').addEventListener('change', filterTable);
-document.getElementById('filterContactMethod').addEventListener('change', filterTable);
-document.getElementById('filterProgram').addEventListener('input', debounce(filterTable, 200));
-document.getElementById('filterResearchArea').addEventListener('input', debounce(filterTable, 200));
-document.getElementById('filterTitle').addEventListener('input', debounce(filterTable, 200));
-document.getElementById('filterUniversity').addEventListener('input', debounce(filterTable, 200));
-document.getElementById('filterDepartment').addEventListener('input', debounce(filterTable, 200));
-document.getElementById('sortBy').addEventListener('change', filterTable);
+// Add checks before attaching listeners
+document.getElementById('globalSearch')?.addEventListener('input', debounce(filterTable, 200));
+document.getElementById('filterHiringStatus')?.addEventListener('change', filterTable);
+document.getElementById('filterContactMethod')?.addEventListener('change', filterTable);
+document.getElementById('filterProgram')?.addEventListener('input', debounce(filterTable, 200));
+document.getElementById('filterResearchArea')?.addEventListener('input', debounce(filterTable, 200));
+document.getElementById('filterTitle')?.addEventListener('input', debounce(filterTable, 200));
+document.getElementById('filterUniversity')?.addEventListener('input', debounce(filterTable, 200));
+document.getElementById('filterDepartment')?.addEventListener('input', debounce(filterTable, 200));
+document.getElementById('sortBy')?.addEventListener('change', filterTable);
 
-// Initial run (optional)
-document.addEventListener('DOMContentLoaded', filterTable);
+// Initial run (optional) - also add check
+document.addEventListener('DOMContentLoaded', () => {
+    if (document.getElementById('professorTable')) {
+        filterTable();
+    }
+});

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,212 +1,276 @@
-// Store the ID of the professor to delete
-let professorToDelete = null;
+(() => {
+  // Store the ID of the professor to delete
+  let professorToDelete = null;
 
-// Function to edit a professor
-function editProfessor(professorId) {
-    // Fetch the professor's data from the server
+  const getById = (id) => document.getElementById(id);
+
+  // --- utils ---
+  const normalize = (s) => (s || "").toString().toLowerCase().trim().replace(/\s+/g, " ");
+  const tokenize = (s) => normalize(s).split(" ").filter(Boolean);
+
+  // Simple debounce for input typing
+  function debounce(fn, delay = 250) {
+    let t;
+    return (...args) => {
+      clearTimeout(t);
+      t = setTimeout(() => fn(...args), delay);
+    };
+  }
+
+  // Function to edit a professor
+  function editProfessor(professorId) {
     fetch(`/get_professor/${professorId}`)
-        .then(response => {
-            if (!response.ok) {
-                throw new Error('Network response was not ok');
-            }
-            return response.json();
-        })
-        .then(data => {
-            // Redirect to the add_professor page with the professor data as query parameters
-            // We'll use URLSearchParams to construct the query string
-            const params = new URLSearchParams();
-            params.append('id', data.id);
-            params.append('name', data.name);
-            params.append('title', data.title);
-            params.append('university_name', data.university_name);
-            params.append('university_country', data.university_country);
-            params.append('university_state', data.university_state);
-            params.append('university_city', data.university_city);
-            params.append('university_ranking', data.university_ranking);
-            params.append('department_name', data.department_name);
-            params.append('email', data.email);
-            params.append('personal_website', data.personal_website);
-            params.append('lab_group_name', data.lab_group_name);
-            params.append('lab_website', data.lab_website);
-            params.append('hiring_status', data.hiring_status);
-            params.append('contact_through', data.contact_through);
-            params.append('form_link', data.form_link);
-            params.append('notes', data.notes);
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        return response.json();
+      })
+      .then((data) => {
+        const params = new URLSearchParams();
+        params.append('id', data.id);
+        params.append('name', data.name);
+        params.append('title', data.title);
+        params.append('university_name', data.university_name);
+        params.append('university_country', data.university_country);
+        params.append('university_state', data.university_state);
+        params.append('university_city', data.university_city);
+        params.append('university_ranking', data.university_ranking);
+        params.append('department_name', data.department_name);
+        params.append('email', data.email);
+        params.append('personal_website', data.personal_website);
+        params.append('lab_group_name', data.lab_group_name);
+        params.append('lab_website', data.lab_website);
+        params.append('hiring_status', data.hiring_status);
+        params.append('contact_through', data.contact_through);
+        params.append('form_link', data.form_link);
+        params.append('notes', data.notes);
+        params.append('program_names', (data.programs || []).join(','));
+        params.append('research_area_names', (data.research_areas || []).join(','));
 
-            // Join program and research area names with commas for input
-            params.append('program_names', data.programs.join(','));
-            params.append('research_area_names', data.research_areas.join(','));
+        window.location.href = `/add_professor?${params.toString()}`;
+      })
+      .catch((error) => {
+        console.error('Error fetching professor data:', error);
+        alert('Error loading professor data for editing.');
+      });
+  }
 
-            window.location.href = `/add_professor?${params.toString()}`;
-        })
-        .catch(error => {
-            console.error('Error fetching professor data:', error);
-            alert('Error loading professor data for editing.');
-        });
-}
+  // Function to delete a professor
+  function deleteProfessor(professorId) {
+    const modalElement = getById('deleteModal');
+    if (!modalElement || typeof bootstrap === 'undefined') {
+      console.warn('Delete modal or Bootstrap is unavailable.');
+      return;
+    }
 
-// Function to delete a professor
-function deleteProfessor(professorId) {
     professorToDelete = professorId;
-    const modal = new bootstrap.Modal(document.getElementById('deleteModal'));
+    const modal = new bootstrap.Modal(modalElement);
     modal.show();
-}
+  }
 
-// Confirm deletion when the confirm button is clicked
-document.getElementById('confirmDeleteBtn').addEventListener('click', function() {
-    if (professorToDelete !== null) {
-        // Send a DELETE request to the server
-        fetch(`/delete_professor/${professorToDelete}`, {
-            method: 'DELETE',
-            headers: {
-                'Content-Type': 'application/json',
-            }
+  // --- core filtering ---
+  function filterTable() {
+    const table = getById('professorTable');
+    if (!table) {
+      return;
+    }
+
+    const tbody = table.querySelector('tbody');
+    if (!tbody) {
+      return;
+    }
+
+    const tokens = tokenize(getById('globalSearch')?.value || '');
+    const hiringStatusFilter = normalize(getById('filterHiringStatus')?.value);
+    const contactMethodFilter = normalize(getById('filterContactMethod')?.value);
+    const programFilter = normalize(getById('filterProgram')?.value);
+    const researchAreaFilter = normalize(getById('filterResearchArea')?.value);
+    const titleFilter = normalize(getById('filterTitle')?.value);
+    const universityFilter = normalize(getById('filterUniversity')?.value);
+    const departmentFilter = normalize(getById('filterDepartment')?.value);
+
+    const rows = tbody.querySelectorAll('tr');
+
+    rows.forEach((row) => {
+      const name = normalize(row.getAttribute('data-name'));
+      const country = normalize(row.getAttribute('data-country'));
+      const city = normalize(row.getAttribute('data-city'));
+      const state = normalize(row.getAttribute('data-state'));
+      const hiringStatus = normalize(row.getAttribute('data-hiring-status'));
+      const contactMethod = normalize(row.getAttribute('data-contact-method'));
+      const title = normalize(row.getAttribute('data-title'));
+      const university = normalize(row.getAttribute('data-university'));
+      const department = normalize(row.getAttribute('data-department'));
+      const programs = normalize(row.querySelector('.programs-cell')?.getAttribute('data-programs') || '');
+      const researchAreas = normalize(row.querySelector('.research-areas-cell')?.getAttribute('data-research-areas') || '');
+
+      const haystack = `${name} ${country} ${city} ${state}`;
+      const matchesGlobal = tokens.every((t) => haystack.includes(t));
+
+      const matchesHiring = !hiringStatusFilter || hiringStatus.includes(hiringStatusFilter);
+      const matchesContact = !contactMethodFilter || contactMethod.includes(contactMethodFilter);
+      const matchesProgram = !programFilter || programs.includes(programFilter);
+      const matchesRA = !researchAreaFilter || researchAreas.includes(researchAreaFilter);
+      const matchesTitle = !titleFilter || title.includes(titleFilter);
+      const matchesUni = !universityFilter || university.includes(universityFilter);
+      const matchesDept = !departmentFilter || department.includes(departmentFilter);
+
+      const show = matchesGlobal && matchesHiring && matchesContact && matchesProgram &&
+        matchesRA && matchesTitle && matchesUni && matchesDept;
+
+      row.style.display = show ? '' : 'none';
+    });
+
+    sortRows();
+  }
+
+  // --- sorting ---
+  function sortRows() {
+    const sortSelect = getById('sortBy');
+    const table = getById('professorTable');
+    if (!sortSelect || !table) {
+      return;
+    }
+
+    const sortBy = sortSelect.value;
+    if (!sortBy) {
+      return;
+    }
+
+    const tbody = table.querySelector('tbody');
+    if (!tbody) {
+      return;
+    }
+
+    const rows = Array.from(tbody.querySelectorAll('tr'));
+    const visibleRows = rows.filter((r) => r.style.display !== 'none');
+
+    const getName = (r) => normalize(r.getAttribute('data-name'));
+    const getRanking = (r) => {
+      const raw = (r.getAttribute('data-ranking') || '').trim();
+      const n = parseFloat(raw);
+      return Number.isFinite(n) ? n : Number.POSITIVE_INFINITY;
+    };
+
+    visibleRows.sort((a, b) => {
+      switch (sortBy) {
+        case 'name-asc':
+          return getName(a).localeCompare(getName(b));
+        case 'name-desc':
+          return getName(b).localeCompare(getName(a));
+        case 'ranking-asc':
+          return getRanking(a) - getRanking(b);
+        case 'ranking-desc':
+          return getRanking(b) - getRanking(a);
+        default:
+          return 0;
+      }
+    });
+
+    visibleRows.forEach((row) => tbody.appendChild(row));
+  }
+
+  // --- clear ---
+  function clearFilters() {
+    const filterIds = [
+      'globalSearch',
+      'filterHiringStatus',
+      'filterContactMethod',
+      'filterProgram',
+      'filterResearchArea',
+      'filterTitle',
+      'filterUniversity',
+      'filterDepartment',
+      'sortBy',
+    ];
+
+    filterIds.forEach((id) => {
+      const el = getById(id);
+      if (el) {
+        el.value = '';
+      }
+    });
+
+    filterTable();
+  }
+
+  function attachFilterListeners() {
+    const map = [
+      ['globalSearch', 'input', debounce(filterTable, 200)],
+      ['filterHiringStatus', 'change', filterTable],
+      ['filterContactMethod', 'change', filterTable],
+      ['filterProgram', 'input', debounce(filterTable, 200)],
+      ['filterResearchArea', 'input', debounce(filterTable, 200)],
+      ['filterTitle', 'input', debounce(filterTable, 200)],
+      ['filterUniversity', 'input', debounce(filterTable, 200)],
+      ['filterDepartment', 'input', debounce(filterTable, 200)],
+      ['sortBy', 'change', filterTable],
+    ];
+
+    map.forEach(([id, event, handler]) => {
+      const el = getById(id);
+      if (el) {
+        el.addEventListener(event, handler);
+      }
+    });
+  }
+
+  function setupDeletionHandler() {
+    const confirmDeleteBtn = getById('confirmDeleteBtn');
+    const modalElement = getById('deleteModal');
+
+    if (!confirmDeleteBtn || !modalElement) {
+      return;
+    }
+
+    confirmDeleteBtn.addEventListener('click', () => {
+      if (professorToDelete === null) {
+        return;
+      }
+
+      fetch(`/delete_professor/${professorToDelete}`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error('Failed to delete professor');
+          }
+
+          const row = document.querySelector(`tr[data-professor-id="${professorToDelete}"]`);
+          if (row) {
+            row.remove();
+          }
+
+          if (typeof bootstrap !== 'undefined') {
+            const modal = bootstrap.Modal.getInstance(modalElement);
+            modal?.hide();
+          }
+
+          professorToDelete = null;
+          location.reload();
         })
-        .then(response => {
-            if (response.ok) {
-                // Remove the row from the table using the professor ID
-                const row = document.querySelector(`tr[data-professor-id="${professorToDelete}"]`);
-                if (row) {
-                    row.remove();
-                }
-                
-                // Hide the modal
-                const modal = bootstrap.Modal.getInstance(document.getElementById('deleteModal'));
-                modal.hide();
-                // Reset the variable
-                professorToDelete = null;
-                location.reload();
-            } else {
-                alert('Error deleting professor');
-            }
-        })
-        .catch(error => {
-            console.error('Error:', error);
-            alert('Error deleting professor');
+        .catch((error) => {
+          console.error('Error deleting professor:', error);
+          alert('Error deleting professor');
         });
-    }
-});
+    });
+  }
 
-// --- utils ---
-const normalize = (s) => (s || "").toString().toLowerCase().trim().replace(/\s+/g, " ");
-const tokenize = (s) => normalize(s).split(" ").filter(Boolean);
+  document.addEventListener('DOMContentLoaded', () => {
+    attachFilterListeners();
+    setupDeletionHandler();
 
-// Simple debounce for input typing
-function debounce(fn, delay = 250) {
-  let t;
-  return (...args) => {
-    clearTimeout(t);
-    t = setTimeout(() => fn(...args), delay);
-  };
-}
-
-// --- core filtering ---
-function filterTable() {
-  // Search only these fields:
-  // name + location (country, city, state)
-  const tokens = tokenize(document.getElementById('globalSearch').value);
-
-  // Filters (do not participate in global search)
-  const hiringStatusFilter = normalize(document.getElementById('filterHiringStatus').value);
-  const contactMethodFilter = normalize(document.getElementById('filterContactMethod').value);
-  const programFilter = normalize(document.getElementById('filterProgram').value);
-  const researchAreaFilter = normalize(document.getElementById('filterResearchArea').value);
-  const titleFilter = normalize(document.getElementById('filterTitle').value);
-  const universityFilter = normalize(document.getElementById('filterUniversity').value);
-  const departmentFilter = normalize(document.getElementById('filterDepartment').value);
-
-  const rows = document.querySelectorAll('#professorTable tbody tr');
-
-  rows.forEach(row => {
-    // row dataset
-    const name = normalize(row.getAttribute('data-name'));
-    const country = normalize(row.getAttribute('data-country'));
-    const city = normalize(row.getAttribute('data-city'));
-    const state = normalize(row.getAttribute('data-state'));
-    const hiringStatus = normalize(row.getAttribute('data-hiring-status'));
-    const contactMethod = normalize(row.getAttribute('data-contact-method'));
-    const title = normalize(row.getAttribute('data-title'));
-    const university = normalize(row.getAttribute('data-university'));
-    const department = normalize(row.getAttribute('data-department'));
-    const programs = normalize(row.querySelector('.programs-cell')?.getAttribute('data-programs') || "");
-    const researchAreas = normalize(row.querySelector('.research-areas-cell')?.getAttribute('data-research-areas') || "");
-
-    // Global search haystack (name + location only)
-    const haystack = `${name} ${country} ${city} ${state}`;
-    const matchesGlobal = tokens.every(t => haystack.includes(t));
-
-    // Independent filters (substring matches)
-    const matchesHiring = !hiringStatusFilter || hiringStatus.includes(hiringStatusFilter);
-    const matchesContact = !contactMethodFilter || contactMethod.includes(contactMethodFilter);
-    const matchesProgram = !programFilter || programs.includes(programFilter);
-    const matchesRA = !researchAreaFilter || researchAreas.includes(researchAreaFilter);
-    const matchesTitle = !titleFilter || title.includes(titleFilter);
-    const matchesUni = !universityFilter || university.includes(universityFilter);
-    const matchesDept = !departmentFilter || department.includes(departmentFilter);
-
-    const show = matchesGlobal && matchesHiring && matchesContact && matchesProgram &&
-                 matchesRA && matchesTitle && matchesUni && matchesDept;
-
-    row.style.display = show ? '' : 'none';
-  });
-
-  sortRows(); // apply current sort on the visible set
-}
-
-// --- sorting ---
-function sortRows() {
-  const sortBy = document.getElementById('sortBy').value;
-  if (!sortBy) return;
-
-  const tbody = document.querySelector('#professorTable tbody');
-  const rows = Array.from(tbody.querySelectorAll('tr'));
-  const visibleRows = rows.filter(r => r.style.display !== 'none');
-
-  const getName = (r) => normalize(r.getAttribute('data-name'));
-  const getRanking = (r) => {
-    const raw = (r.getAttribute('data-ranking') || '').trim();
-    const n = parseFloat(raw);
-    return Number.isFinite(n) ? n : Number.POSITIVE_INFINITY; // push non-numeric to bottom
-  };
-
-  visibleRows.sort((a, b) => {
-    switch (sortBy) {
-      case 'name-asc':   return getName(a).localeCompare(getName(b));
-      case 'name-desc':  return getName(b).localeCompare(getName(a));
-      case 'ranking-asc':  return getRanking(a) - getRanking(b);
-      case 'ranking-desc': return getRanking(b) - getRanking(a);
-      default: return 0;
+    if (getById('professorTable')) {
+      filterTable();
     }
   });
 
-  // Re-append visible rows in new order, keep hidden in place
-  visibleRows.forEach(r => tbody.appendChild(r));
-}
-
-// --- clear ---
-function clearFilters() {
-  document.getElementById('globalSearch').value = '';
-  document.getElementById('filterHiringStatus').value = '';
-  document.getElementById('filterContactMethod').value = '';
-  document.getElementById('filterProgram').value = '';
-  document.getElementById('filterResearchArea').value = '';
-  document.getElementById('filterTitle').value = '';
-  document.getElementById('filterUniversity').value = '';
-  document.getElementById('filterDepartment').value = '';
-  document.getElementById('sortBy').value = '';
-  filterTable();
-}
-
-// --- wire up live filtering ---
-document.getElementById('globalSearch').addEventListener('input', debounce(filterTable, 200));
-document.getElementById('filterHiringStatus').addEventListener('change', filterTable);
-document.getElementById('filterContactMethod').addEventListener('change', filterTable);
-document.getElementById('filterProgram').addEventListener('input', debounce(filterTable, 200));
-document.getElementById('filterResearchArea').addEventListener('input', debounce(filterTable, 200));
-document.getElementById('filterTitle').addEventListener('input', debounce(filterTable, 200));
-document.getElementById('filterUniversity').addEventListener('input', debounce(filterTable, 200));
-document.getElementById('filterDepartment').addEventListener('input', debounce(filterTable, 200));
-document.getElementById('sortBy').addEventListener('change', filterTable);
-
-// Initial run (optional)
-document.addEventListener('DOMContentLoaded', filterTable);
+  // Expose functions for inline handlers
+  window.editProfessor = editProfessor;
+  window.deleteProfessor = deleteProfessor;
+  window.clearFilters = clearFilters;
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,9 +12,16 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
         <div class="container">
             <a class="navbar-brand" href="{{ url_for('index') }}">PhD Application Tracker</a>
-            <!-- <div class="navbar-nav">
-                <a class="nav-link" href="{{ url_for('add_professor') }}">Add Professor</a>
-            </div> -->
+            <div class="navbar-nav">
+                {# Show different CTA based on the current page #}
+                {% if request.endpoint in ['programs_list', 'programs.programs_list'] %}
+                    <a class="nav-link" href="{{ url_for('index') }}">Browse Professors</a>
+                {% elif request.endpoint in ['add_professor'] %}
+                    <a class="nav-link" href="{{ url_for('programs_list') }}">Browse Programs</a>
+                {% else %}
+                    <a class="nav-link" href="{{ url_for('programs_list') }}">Browse Programs</a>
+                {% endif %}
+            </div>
         </div>
     </nav>
 
@@ -23,6 +30,5 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="{{ url_for('static', filename='js/main.js') }}"></script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -161,4 +161,5 @@
         </div>
     </div>
 </div>
+<script src="{{ url_for('static', filename='js/main.js') }}"></script>
 {% endblock %}

--- a/templates/programs_list.html
+++ b/templates/programs_list.html
@@ -1,0 +1,113 @@
+<!-- templates/programs_list.html -->
+{% extends "base.html" %}
+
+{% block content %}
+<!-- ... (your existing HTML content remains the same) ... -->
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Programs List</h1>
+    <a href="{{ url_for('index') }}" class="btn btn-outline-primary" title="Back to Professors" aria-label="Back to Professors">
+        <i class="bi bi-arrow-left" aria-hidden="true"></i> Back to Professors
+        <span class="visually-hidden">Back to Professors</span>
+    </a>
+</div>
+
+<!-- Search and Filter Section
+<div class="card mb-4">
+  <div class="card-body">
+    <div class="d-flex flex-wrap align-items-center gap-2 justify-content-between">
+      <h5 class="mb-0">Find Programs</h5>
+      <div class="d-flex gap-2">
+        <select class="form-select form-select-sm" id="sortBy" aria-label="Sort by">
+          <option value="">Sort by…</option>
+          <option value="program-asc">Program (A→Z)</option>
+          <option value="program-desc">Program (Z→A)</option>
+          <option value="department-asc">Department (A→Z)</option>
+          <option value="department-desc">Department (Z→A)</option>
+          <option value="university-asc">University (A→Z)</option>
+          <option value="university-desc">University (Z→A)</option>
+          <option value="professors-asc">Professors (Low→High)</option>
+          <option value="professors-desc">Professors (High→Low)</option>
+          <option value="ranking-asc">Ranking (Low→High)</option>
+          <option value="ranking-desc">Ranking (High→Low)</option>
+        </select>
+        <button class="btn btn-outline-secondary btn-sm" onclick="clearProgramFilters()">Clear</button>
+      </div>
+    </div>
+
+    Primary search row: name/location + key filters
+    <div class="mt-3">
+        <div class="search-grid">
+            <input type="text" class="form-control" id="programSearch"
+                placeholder="Search by program, dept, uni, or location…" aria-label="Search by program, department, university, or location">
+
+            <input type="text" class="form-control" id="filterProgram" placeholder="Filter by program name…">
+            <input type="text" class="form-control" id="filterDepartment" placeholder="Filter by department…">
+            <input type="text" class="form-control" id="filterUniversity" placeholder="Filter by university…">
+        </div>
+    </div>
+
+    <div class="mt-2">
+    <button class="btn btn-link p-0" type="button" data-bs-toggle="collapse" data-bs-target="#advancedProgramFilters" aria-expanded="false">
+        Advanced filters
+    </button>
+
+    <div class="collapse" id="advancedProgramFilters">
+        <div class="advanced-grid mt-1">
+            <input type="text" class="form-control" id="filterCountry" placeholder="Filter by country…">
+            <input type="text" class="form-control" id="filterState" placeholder="Filter by state/province…">
+            <input type="text" class="form-control" id="filterCity" placeholder="Filter by city…">
+            <input type="number" class="form-control" id="filterRankingMin" placeholder="Min Ranking" min="0">
+            <input type="number" class="form-control" id="filterRankingMax" placeholder="Max Ranking" min="0">
+            <input type="number" class="form-control" id="filterProfMin" placeholder="Min Professors" min="0">
+            <input type="number" class="form-control" id="filterProfMax" placeholder="Max Professors" min="0">
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="filterHasProfessors">
+                <label class="form-check-label" for="filterHasProfessors">
+                    Has Professors
+                </label>
+            </div>
+        </div>
+    </div>
+    </div>
+  </div>
+</div> -->
+
+<!-- Table Container (Ensures horizontal scrolling if needed) -->
+<div class="table-container">
+    <table class="table table-striped" id="programsTable">
+        <thead>
+            <tr>
+                <th scope="col" class="text-center">Department</th>
+                <th scope="col" class="text-center">University</th>
+                <th scope="col" class="text-center">Location</th>
+                <th scope="col" class="text-center">Program</th>
+                <th scope="col" class="text-center">Professors</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for program in programs %}
+            {% set dept = program.department %}
+            {% set uni = dept.university %}
+            {% set prof_count = program.professors|length %}
+            <tr
+                data-program="{{ program.name|lower }}"
+                data-department="{{ dept.name|lower }}"
+                data-university="{{ uni.name|lower }}"
+                data-country="{{ uni.country|lower }}"
+                data-state="{{ (uni.state or '')|lower }}"
+                data-city="{{ uni.city|lower }}"
+                data-location="{{ (uni.city ~ ' ' ~ (uni.state or '') ~ ' ' ~ uni.country)|lower }}"
+                data-ranking="{{ uni.ranking_usnews or '' }}"
+                data-professors="{{ prof_count }}"
+            >
+                <td>{{ dept.name }}</td>
+                <td>{{ uni.name }}</td>
+                <td>{{ uni.city }}{% if uni.state %}, {{ uni.state }}{% endif %}{% if uni.country %}, {{ uni.country }}{% endif %}</td>
+                <td>{{ program.name }}</td>
+                <td class="text-center">{{ prof_count }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- wrap the main script in an IIFE and expose only the globals needed by inline handlers
- add guards before wiring up table filters and sorters so the script works on pages without those elements
- protect deletion modal logic and fetch handlers to avoid runtime errors when the modal is absent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e63c3ac2f48331ba89da8fbd28b34a