### PR TITLE
Add filtering and sorting UI for programs list

### DIFF
--- a/templates/programs_list.html
+++ b/templates/programs_list.html
@@ -2,7 +2,6 @@
 {% extends "base.html" %}
 
 {% block content %}
-<!-- ... (your existing HTML content remains the same) ... -->
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1>Programs List</h1>
     <a href="{{ url_for('index') }}" class="btn btn-outline-primary" title="Back to Professors" aria-label="Back to Professors">
@@ -11,68 +10,66 @@
     </a>
 </div>
 
-<!-- Search and Filter Section
 <div class="card mb-4">
-  <div class="card-body">
-    <div class="d-flex flex-wrap align-items-center gap-2 justify-content-between">
-      <h5 class="mb-0">Find Programs</h5>
-      <div class="d-flex gap-2">
-        <select class="form-select form-select-sm" id="sortBy" aria-label="Sort by">
-          <option value="">Sort by…</option>
-          <option value="program-asc">Program (A→Z)</option>
-          <option value="program-desc">Program (Z→A)</option>
-          <option value="department-asc">Department (A→Z)</option>
-          <option value="department-desc">Department (Z→A)</option>
-          <option value="university-asc">University (A→Z)</option>
-          <option value="university-desc">University (Z→A)</option>
-          <option value="professors-asc">Professors (Low→High)</option>
-          <option value="professors-desc">Professors (High→Low)</option>
-          <option value="ranking-asc">Ranking (Low→High)</option>
-          <option value="ranking-desc">Ranking (High→Low)</option>
-        </select>
-        <button class="btn btn-outline-secondary btn-sm" onclick="clearProgramFilters()">Clear</button>
-      </div>
-    </div>
-
-    Primary search row: name/location + key filters
-    <div class="mt-3">
-        <div class="search-grid">
-            <input type="text" class="form-control" id="programSearch"
-                placeholder="Search by program, dept, uni, or location…" aria-label="Search by program, department, university, or location">
-
-            <input type="text" class="form-control" id="filterProgram" placeholder="Filter by program name…">
-            <input type="text" class="form-control" id="filterDepartment" placeholder="Filter by department…">
-            <input type="text" class="form-control" id="filterUniversity" placeholder="Filter by university…">
+    <div class="card-body">
+        <div class="d-flex flex-wrap align-items-center gap-2 justify-content-between">
+            <h5 class="mb-0">Find Programs</h5>
+            <div class="d-flex gap-2">
+                <select class="form-select form-select-sm" id="programSortBy" aria-label="Sort programs by">
+                    <option value="">Sort by…</option>
+                    <option value="program-asc">Program (A→Z)</option>
+                    <option value="program-desc">Program (Z→A)</option>
+                    <option value="department-asc">Department (A→Z)</option>
+                    <option value="department-desc">Department (Z→A)</option>
+                    <option value="university-asc">University (A→Z)</option>
+                    <option value="university-desc">University (Z→A)</option>
+                    <option value="professors-asc">Professors (Low→High)</option>
+                    <option value="professors-desc">Professors (High→Low)</option>
+                    <option value="ranking-asc">Ranking (Low→High)</option>
+                    <option value="ranking-desc">Ranking (High→Low)</option>
+                </select>
+                <button class="btn btn-outline-secondary btn-sm" type="button" onclick="clearProgramFilters()">Clear</button>
+            </div>
         </div>
-    </div>
 
-    <div class="mt-2">
-    <button class="btn btn-link p-0" type="button" data-bs-toggle="collapse" data-bs-target="#advancedProgramFilters" aria-expanded="false">
-        Advanced filters
-    </button>
+        <div class="mt-3">
+            <div class="search-grid">
+                <input type="text" class="form-control" id="programGlobalSearch"
+                       placeholder="Search by program, department, university, or location…"
+                       aria-label="Search by program, department, university, or location">
 
-    <div class="collapse" id="advancedProgramFilters">
-        <div class="advanced-grid mt-1">
-            <input type="text" class="form-control" id="filterCountry" placeholder="Filter by country…">
-            <input type="text" class="form-control" id="filterState" placeholder="Filter by state/province…">
-            <input type="text" class="form-control" id="filterCity" placeholder="Filter by city…">
-            <input type="number" class="form-control" id="filterRankingMin" placeholder="Min Ranking" min="0">
-            <input type="number" class="form-control" id="filterRankingMax" placeholder="Max Ranking" min="0">
-            <input type="number" class="form-control" id="filterProfMin" placeholder="Min Professors" min="0">
-            <input type="number" class="form-control" id="filterProfMax" placeholder="Max Professors" min="0">
-            <div class="form-check">
-                <input class="form-check-input" type="checkbox" id="filterHasProfessors">
-                <label class="form-check-label" for="filterHasProfessors">
-                    Has Professors
-                </label>
+                <input type="text" class="form-control" id="programFilterName" placeholder="Filter by program name…" aria-label="Filter by program name">
+                <input type="text" class="form-control" id="programFilterDepartment" placeholder="Filter by department…" aria-label="Filter by department">
+                <input type="text" class="form-control" id="programFilterUniversity" placeholder="Filter by university…" aria-label="Filter by university">
+            </div>
+        </div>
+
+        <div class="mt-2">
+            <button class="btn btn-link p-0" type="button" data-bs-toggle="collapse" data-bs-target="#advancedProgramFilters" aria-expanded="false">
+                Advanced filters
+            </button>
+
+            <div class="collapse" id="advancedProgramFilters">
+                <div class="advanced-grid mt-1">
+                    <input type="text" class="form-control" id="programFilterCountry" placeholder="Filter by country…" aria-label="Filter by country">
+                    <input type="text" class="form-control" id="programFilterState" placeholder="Filter by state or province…" aria-label="Filter by state or province">
+                    <input type="text" class="form-control" id="programFilterCity" placeholder="Filter by city…" aria-label="Filter by city">
+                    <input type="number" class="form-control" id="programFilterRankingMin" placeholder="Min ranking" min="0" aria-label="Minimum ranking">
+                    <input type="number" class="form-control" id="programFilterRankingMax" placeholder="Max ranking" min="0" aria-label="Maximum ranking">
+                    <input type="number" class="form-control" id="programFilterProfMin" placeholder="Min professors" min="0" aria-label="Minimum number of professors">
+                    <input type="number" class="form-control" id="programFilterProfMax" placeholder="Max professors" min="0" aria-label="Maximum number of professors">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="programFilterHasProfessors">
+                        <label class="form-check-label" for="programFilterHasProfessors">
+                            Has professors
+                        </label>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
-    </div>
-  </div>
-</div> -->
+</div>
 
-<!-- Table Container (Ensures horizontal scrolling if needed) -->
 <div class="table-container">
     <table class="table table-striped" id="programsTable">
         <thead>
@@ -110,4 +107,6 @@
         </tbody>
     </table>
 </div>
+
+<script src="{{ url_for('static', filename='js/main.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a search, filter, and sort toolbar to the programs list view that matches the professor page
- extend the main JavaScript utilities to filter, sort, and clear the programs table using the new controls

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e6404a0f18833183116c5f1cce195e