### PR TITLE
Fix program professor counts

### DIFF
--- a/templates/programs_list.html
+++ b/templates/programs_list.html
@@ -82,10 +82,10 @@
             </tr>
         </thead>
         <tbody>
-            {% for program in programs %}
+            {% for program, prof_count in programs %}
             {% set dept = program.department %}
             {% set uni = dept.university %}
-            {% set prof_count = program.professors|length %}
+            {% set prof_count = prof_count or 0 %}
             <tr
                 data-program="{{ program.name|lower }}"
                 data-department="{{ dept.name|lower }}"


### PR DESCRIPTION
## Summary
- aggregate professor counts per program in the programs list query so the counts stay current
- update the template to consume the aggregated counts while preserving existing filters and sorting

## Testing
- python - <<'PY'
from app import app, db, Professor, University, Department, Program, HiringStatus, ContactThrough

with app.app_context():
    db.drop_all(); db.create_all()
    uni = University(name='Uni', country='USA', state='CA', city='City', ranking_usnews=5)
    dept = Department(name='CS', university=uni)
    prog = Program(name='CS PhD', department=dept)
    db.session.add_all([uni, dept, prog]); db.session.commit()

    prof = Professor(name='Prof', title='Prof', university=uni, department=dept,
                     email='prof@example.com', hiring_status=HiringStatus.HIRING,
                     contact_through=ContactThrough.EMAIL)
    prof.programs.append(prog)
    db.session.add(prof); db.session.commit()

    client = app.test_client(); resp = client.get('/programs')
    import re
    counts = re.findall(r'<td class="text-center">(\d+)</td>', resp.data.decode())
    print('Counts after add:', counts)

    db.session.delete(prof); db.session.commit()
    resp2 = client.get('/programs')
    counts2 = re.findall(r'<td class="text-center">(\d+)</td>', resp2.data.decode())
    print('Counts after delete:', counts2)
PY

------
https://chatgpt.com/codex/tasks/task_e_68e6429aabcc8331838b023d064db7e3